### PR TITLE
fix: Global step resume from recipe_state

### DIFF
--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -323,6 +323,9 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         ):
             self._steps_per_epoch = self.max_steps_per_epoch
 
+        # may have been already loaded if run is resumed
+        self.global_step = self.global_step or self.epochs_run * self._steps_per_epoch
+
         # For now, default to saving at epoch boundaries
         if self.save_every_n_steps is None:
             self.save_every_n_steps = self._steps_per_epoch
@@ -679,8 +682,10 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             # in case shuffle is True
             self._sampler.set_epoch(curr_epoch)
 
-            pbar = tqdm(total=self._steps_per_epoch)
-            pbar.update(self.global_step % self._steps_per_epoch)
+            pbar = tqdm(
+                range(self.global_step % self._steps_per_epoch, self._steps_per_epoch),
+                initial=self.global_step % self._steps_per_epoch,
+            )
             pbar.set_description(f"{curr_epoch + 1}|{self.global_step}|Loss: ?")
             for idx, batch in enumerate(self._dataloader):
                 if (


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/20cee82e-a48a-4409-84eb-69fa732c2987)

<img width="581" alt="image" src="https://github.com/user-attachments/assets/0768c40f-b157-49c1-b186-9a351ed78e9c" />

Tested between epochs too