### PR TITLE
Test Fixes for Step Based Checkpointing

### DIFF
--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -979,10 +979,9 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                     self._profiler.step()
 
             self.epochs_run += 1
-            
-            self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
         self._profiler.stop()
+        self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
     def cleanup(self) -> None:
         if self._is_rank_zero:

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -981,8 +981,6 @@ class FullDPORecipeDistributed(FTRecipeInterface):
 
             self.epochs_run += 1
 
-        self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
-
         self._profiler.stop()
         self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -718,6 +718,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
             ),
             epoch=epoch,
             full_tensors=full_tensors,
+            dir_prefix=self.checkpoint_dir_prefix,
         )
 
     def concatenated_forward(
@@ -980,7 +981,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
 
             self.epochs_run += 1
             
-            self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
+        self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
         self._profiler.stop()
 

--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -958,7 +958,12 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                         )
 
                     # Save checkpoint if specified by user
-                    if self.global_step % self.save_every_n_steps == 0:
+                    is_final_step = (
+                        (curr_epoch == self.total_epochs - 1)
+                        and ((idx + 1) // self._gradient_accumulation_steps) == self.max_steps_per_epoch
+                    )
+
+                    if self.global_step % self.save_every_n_steps == 0 and not is_final_step:
                         self.save_checkpoint(epoch=curr_epoch, full_tensors=False)
 
                     # Reset running stats for the next step
@@ -974,8 +979,8 @@ class FullDPORecipeDistributed(FTRecipeInterface):
                     self._profiler.step()
 
             self.epochs_run += 1
-            if not self._enable_async_checkpointing:
-                self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
+            
+            self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
         self._profiler.stop()
 

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -1141,7 +1141,8 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             self.epochs_run += 1
 
         self._profiler.stop()
-        self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
+        if not self._enable_async_checkpointing:
+            self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
     def cleanup(self) -> None:
         if self._is_rank_zero:

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -1141,8 +1141,8 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             self.epochs_run += 1
 
         self._profiler.stop()
-        if not self._enable_async_checkpointing:
-            self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
+
+        self.save_checkpoint(epoch=self.total_epochs - 1, full_tensors=True)
 
     def cleanup(self) -> None:
         if self._is_rank_zero:

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -442,11 +442,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             shuffle=cfg.shuffle,
             batch_size=cfg.batch_size,
             collate_fn=collate_name,
-            dataloader_state_dict=(
-                state_dict[training.DATALOADER_KEY]
-                if training.DATALOADER_KEY in state_dict
-                else None
-            ),
+            dataloader_state_dict=state_dict.get(training.DATALOADER_KEY, None),
         )
 
         # Setup validation dataloader if validation dataset is provided

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -537,7 +537,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             optimizer=self.optimizer,
             training_progress=TrainingProgress(
                 seed=self.seed,
-                epochs_run=self.epochs_run,
+                epochs_run=epoch,
                 total_epochs=self.total_epochs,
                 max_steps_per_epoch=self.max_steps_per_epoch,
                 dataloader_state_dict=self._dataloader.state_dict(),

--- a/recipes/full_finetune_single_device.py
+++ b/recipes/full_finetune_single_device.py
@@ -690,8 +690,9 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             self.epochs_run += 1
 
         self._profiler.stop()
+
         # Save final checkpoint
-        self.save_checkpoint(epoch=curr_epoch, step=self.global_step, full_tensors=True)
+        self.save_checkpoint(epoch=self.total_epochs - 1, step=self.global_step, full_tensors=True)
 
     def cleanup(self) -> None:
         self._metric_logger.close()

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -700,7 +700,7 @@ class KDRecipeDistributed(FTRecipeInterface):
 
     def _loss_step(
         self, batch: dict[str, torch.Tensor]
-    ) -> (torch.Tensor, torch.Tensor):
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         # Both are shape [b, s]
         tokens, labels = batch["tokens"], batch["labels"]
 

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -156,6 +156,7 @@ class KDRecipeDistributed(FTRecipeInterface):
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
         self._kd_ratio = cfg.get("kd_ratio", 0.5)
+        self.save_every_n_steps = cfg.get("save_every_n_steps")
 
     def load_teacher_checkpoint(self, cfg: DictConfig) -> dict[str, Any]:
         """
@@ -328,6 +329,12 @@ class KDRecipeDistributed(FTRecipeInterface):
         ):
             self._steps_per_epoch = self.max_steps_per_epoch
             self.global_step = self.epochs_run * self._steps_per_epoch
+
+        if self.save_every_n_steps is None:
+            self.save_every_n_steps = self._steps_per_epoch
+            self.checkpoint_dir_prefix = "epoch"
+        else:
+            self.checkpoint_dir_prefix = "step"
 
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
@@ -673,7 +680,7 @@ class KDRecipeDistributed(FTRecipeInterface):
 
         return dataloader
 
-    def save_checkpoint(self, epoch: int) -> None:
+    def save_checkpoint(self, epoch: int, full_tensors: bool) -> None:
         self._checkpoint_client.save_checkpoint(
             model=self._model,
             optimizer=self._optimizer,
@@ -685,6 +692,8 @@ class KDRecipeDistributed(FTRecipeInterface):
                 dataloader_state_dict=self._dataloader.state_dict(),
             ),
             epoch=epoch,
+            full_tensors=full_tensors,
+            dir_prefix=self.checkpoint_dir_prefix,
             adapter_config=self._adapter_config.copy(),
             adapter_only=self._save_adapter_weights_only,
         )
@@ -833,6 +842,15 @@ class KDRecipeDistributed(FTRecipeInterface):
                             step=self.global_step,
                         )
 
+                    # Save checkpoint if specified by user
+                    is_final_step = (
+                        (curr_epoch == self.total_epochs - 1)
+                        and ((idx + 1) // self._gradient_accumulation_steps) == self.max_steps_per_epoch
+                    )
+
+                    if self.global_step % self.save_every_n_steps == 0 and not is_final_step:
+                        self.save_checkpoint(epoch=curr_epoch, full_tensors=False)
+
                     # Reset running stats for the next step
                     running_class_loss = 0
                     running_kd_loss = 0
@@ -857,7 +875,8 @@ class KDRecipeDistributed(FTRecipeInterface):
                 self._profiler.step()
 
             self.epochs_run += 1
-            self.save_checkpoint(epoch=curr_epoch)
+        
+        self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
         self._profiler.stop()
 

--- a/recipes/knowledge_distillation_distributed.py
+++ b/recipes/knowledge_distillation_distributed.py
@@ -11,6 +11,7 @@ from functools import partial
 from typing import Any, Optional, Union
 from warnings import warn
 
+import hashlib
 import torch
 from omegaconf import DictConfig, ListConfig
 
@@ -176,6 +177,7 @@ class KDRecipeDistributed(FTRecipeInterface):
         """
         try:
             self.epochs_run = ckpt_dict[training.EPOCHS_KEY]
+            self.global_step = ckpt_dict[training.STEPS_KEY]
 
             # on mismatch, warn the user and prevent the override
             if self.seed != ckpt_dict[training.SEED_KEY]:
@@ -311,6 +313,7 @@ class KDRecipeDistributed(FTRecipeInterface):
             cfg_dataset=cfg.dataset,
             shuffle=cfg.shuffle,
             batch_size=cfg.batch_size,
+            dataloader_state_dict=checkpoint_dict.get(training.DATALOADER_KEY, None),
         )
 
         # Finally update the recipe state which can only be correctly set after all of the
@@ -335,6 +338,12 @@ class KDRecipeDistributed(FTRecipeInterface):
             self.checkpoint_dir_prefix = "epoch"
         else:
             self.checkpoint_dir_prefix = "step"
+
+        if (
+            self._resume_from_checkpoint
+            and self.global_step % self._steps_per_epoch == 0
+        ):
+            list(self._dataloader)
 
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
@@ -632,6 +641,7 @@ class KDRecipeDistributed(FTRecipeInterface):
         cfg_dataset: DictConfig,
         shuffle: bool,
         batch_size: int,
+        dataloader_state_dict: Optional[dict[str, Any]] = None,
     ) -> StatefulDataLoader:
         """
         All data related setup happens here. This recipe currently supports only
@@ -676,18 +686,26 @@ class KDRecipeDistributed(FTRecipeInterface):
             drop_last=True,
         )
 
+        if dataloader_state_dict is not None:
+            dataloader.load_state_dict(dataloader_state_dict)
+
         utils.log_rank_zero(self._logger, "Dataset and Sampler are initialized.")
 
         return dataloader
 
     def save_checkpoint(self, epoch: int, full_tensors: bool) -> None:
+        training_progress_epoch = epoch
+        if self.global_step % self._steps_per_epoch == 0:
+            training_progress_epoch += 1
+
         self._checkpoint_client.save_checkpoint(
             model=self._model,
             optimizer=self._optimizer,
             training_progress=TrainingProgress(
                 seed=self.seed,
-                epochs_run=self.epochs_run,
+                epochs_run=training_progress_epoch,
                 total_epochs=self.total_epochs,
+                steps_run=self.global_step,
                 max_steps_per_epoch=self.max_steps_per_epoch,
                 dataloader_state_dict=self._dataloader.state_dict(),
             ),

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -164,6 +164,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         """
         try:
             self.epochs_run = ckpt_dict[training.EPOCHS_KEY]
+            self.global_step = ckpt_dict[training.STEPS_KEY]
 
             # on mismatch, warn the user and prevent the override
             if self.seed != ckpt_dict[training.SEED_KEY]:
@@ -299,6 +300,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
             cfg_dataset=cfg.dataset,
             batch_size=cfg.batch_size,
             shuffle=cfg.shuffle,
+            dataloader_state_dict=checkpoint_dict.get(training.DATALOADER_KEY, None),
         )
 
         # Finally update the recipe state which can only be correctly set after all of the
@@ -323,6 +325,12 @@ class KDRecipeSingleDevice(FTRecipeInterface):
             self.checkpoint_dir_prefix = "epoch"
         else:
             self.checkpoint_dir_prefix = "step"
+
+        if (
+            self._resume_from_checkpoint
+            and self.global_step % self._steps_per_epoch == 0
+        ):
+            list(self._dataloader)
 
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
@@ -509,6 +517,7 @@ class KDRecipeSingleDevice(FTRecipeInterface):
         cfg_dataset: DictConfig,
         shuffle: bool,
         batch_size: int,
+        dataloader_state_dict: Optional[dict[str, Any]] = None,
     ) -> StatefulDataLoader:
         """
         All data related setup happens here. This recipe currently supports only
@@ -550,15 +559,22 @@ class KDRecipeSingleDevice(FTRecipeInterface):
             drop_last=True,
         )
 
+        if dataloader_state_dict is not None:
+            dataloader.load_state_dict(dataloader_state_dict)
+
         return dataloader
 
     def save_checkpoint(self, epoch: int, full_tensors: bool) -> None:
+        training_progress_epoch = epoch
+        if self.global_step % self._steps_per_epoch == 0:
+            training_progress_epoch += 1
+
         self._checkpoint_client.save_checkpoint(
             model=self._model,
             optimizer=self._optimizer,
             training_progress=TrainingProgress(
                 seed=self.seed,
-                epochs_run=self.epochs_run,
+                epochs_run=training_progress_epoch,
                 total_epochs=self.total_epochs,
                 max_steps_per_epoch=self.max_steps_per_epoch,
                 dataloader_state_dict=self._dataloader.state_dict(),

--- a/recipes/knowledge_distillation_single_device.py
+++ b/recipes/knowledge_distillation_single_device.py
@@ -238,6 +238,18 @@ class KDRecipeSingleDevice(FTRecipeInterface):
             model_state_dict=teacher_checkpoint_dict[training.MODEL_KEY],
         )
 
+        self._tokenizer = config.instantiate(cfg.tokenizer)
+        self._logger.info("Tokenizer is initialized from file.")
+
+        self._optimizer = self._setup_optimizer(
+            cfg_optimizer=cfg.optimizer,
+            opt_state_dict=(
+                checkpoint_dict[training.OPT_KEY]
+                if training.OPT_KEY in checkpoint_dict
+                else None
+            ),
+        )
+
         if self._resume_from_checkpoint:
             # If async checkpointing is enabled, intermediate checkpoints are saved asynchronously
             # using the DistributedCheckpointer.
@@ -258,18 +270,6 @@ class KDRecipeSingleDevice(FTRecipeInterface):
 
             # Update the recipe state from the checkpoint state dict.
             self._update_recipe_state(checkpoint_dict)
-
-        self._tokenizer = config.instantiate(cfg.tokenizer)
-        self._logger.info("Tokenizer is initialized from file.")
-
-        self._optimizer = self._setup_optimizer(
-            cfg_optimizer=cfg.optimizer,
-            opt_state_dict=(
-                checkpoint_dict[training.OPT_KEY]
-                if self._resume_from_checkpoint
-                else None
-            ),
-        )
 
         # initialize loss
         self._loss_fn = config.instantiate(cfg.loss)

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -144,11 +144,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
             cfg.device, offload_ops_to_cpu=True
         )
 
-        self._logger = utils.get_logger(cfg.log_level)
-        self._logger.info(f'{self.distributed_backend=}')
-        self._logger.info(f'{self.fsdp_cpu_offload=}')
-        self._logger.info(f'{self._enable_async_checkpointing=}')
-        init_process_group(self.distributed_backend, timeout=timedelta(seconds=20))
+        init_process_group(self.distributed_backend)
 
         self.world_size, self.rank = utils.get_world_size_and_rank()
 
@@ -161,6 +157,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
         self._log_every_n_steps = cfg.get("log_every_n_steps", 1)
         self._log_peak_memory_stats = cfg.get("log_peak_memory_stats", False)
         self.save_every_n_steps = cfg.get("save_every_n_steps")
+        self._logger = utils.get_logger(cfg.log_level)
         
 
         if (

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -741,8 +741,8 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     # Accumulate running metrics across all devices
                     torch.distributed.all_reduce(running_loss)
 
-                    # if num_tokens.device.type == "cpu":
-                    #     num_tokens = num_tokens.to(self._device)
+                    if num_tokens.device.type != self._device.type:
+                        num_tokens = num_tokens.to(self._device)
 
                     torch.distributed.all_reduce(num_tokens)
 

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -144,6 +144,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
+        self.save_every_n_steps = cfg.get("save_every_n_steps")
 
     def _update_recipe_state(self, ckpt_dict: dict[str, Any]) -> None:
         """
@@ -271,6 +272,18 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         ):
             self._steps_per_epoch = self.max_steps_per_epoch
             self.global_step = self.epochs_run * self._steps_per_epoch
+
+        if self.save_every_n_steps is None:
+            self.save_every_n_steps = self._steps_per_epoch
+            self.checkpoint_dir_prefix = "epoch"
+        else:
+            self.checkpoint_dir_prefix = "step"
+
+        if (
+            self._resume_from_checkpoint
+            and self.global_step % self._steps_per_epoch == 0
+        ):
+            list(self._dataloader)
 
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
@@ -423,7 +436,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
 
         return dataloader
 
-    def save_checkpoint(self, epoch: int) -> None:
+    def save_checkpoint(self, epoch: int, full_tensors: bool) -> None:
         self._checkpoint_client.save_checkpoint(
             model=self._model,
             optimizer=self._optimizer,
@@ -438,6 +451,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             adapter_config=self._adapter_config.copy(),
             adapter_only=self._save_adapter_weights_only,
             single_device=True,
+            full_tensors=full_tensors
         )
 
     def concatenated_forward(
@@ -580,13 +594,22 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                             step=self.global_step,
                         )
 
+                    is_final_step = (
+                        (curr_epoch == self.total_epochs - 1)
+                        # and ((idx + 1) // self._gradient_accumulation_steps) == self.max_steps_per_epoch
+                    )
+
+                    if self.global_step % self.save_every_n_steps == 0 and not is_final_step:
+                        self.save_checkpoint(epoch=curr_epoch, full_tensors=False)
+
                     # Reset running stats for the next step
                     running_loss = 0
                     num_tokens = 0
                     t0 = time.perf_counter()
 
             self.epochs_run += 1
-            self.save_checkpoint(epoch=curr_epoch)
+        
+        self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
     def cleanup(self) -> None:
         self._metric_logger.close()

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -817,7 +817,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             self.epochs_run += 1
 
         self._profiler.stop()
-        self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
+        if not self._enable_async_checkpointing:
+            self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
     def _loss_step(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
         # Shape [b, s], needed for the loss not the model

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -825,9 +825,6 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
 
         self._profiler.stop()
 
-        if dist.is_initialized():
-            dist.barrier()
-
         self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
     def _loss_step(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:

--- a/recipes/lora_finetune_distributed.py
+++ b/recipes/lora_finetune_distributed.py
@@ -160,6 +160,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         self._log_peak_memory_stats = cfg.get("log_peak_memory_stats", False)
         self._logger = utils.get_logger(cfg.log_level)
 
+        self.save_every_n_steps = cfg.get("save_every_n_steps")
+
         if (
             self._log_peak_memory_stats
             and self._device.type not in VALID_BACKENDS_FOR_MEMORY_STATS
@@ -384,6 +386,13 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         ):
             self._steps_per_epoch = self.max_steps_per_epoch
         self.global_step = self.epochs_run * self._steps_per_epoch
+
+        self.checkpoint_dir_prefix = ""
+        if self.save_every_n_steps is None:
+            self.save_every_n_steps = self._steps_per_epoch
+            self.checkpoint_dir_prefix = "epoch"
+        else:
+            self.checkpoint_dir_prefix = "step"
 
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
@@ -650,6 +659,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
     def save_checkpoint(
         self,
         epoch: int,
+        full_tensors: bool,
     ) -> None:
         self._checkpoint_client.save_checkpoint(
             model=self._model,
@@ -664,6 +674,8 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
             epoch=epoch,
             adapter_config=self._adapter_config.copy(),
             adapter_only=self._save_adapter_weights_only,
+            full_tensors=full_tensors,
+            dir_prefix=self.checkpoint_dir_prefix,
         )
 
     def train(self) -> None:
@@ -786,6 +798,9 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     # will include multiple forward / backward passes if gradient accumulation > 1
                     self._profiler.step()
 
+                    if self.global_step % self.save_every_n_steps == 0:
+                        self.save_checkpoint(epoch=curr_epoch, full_tensors=False)
+
                     # Run validation after gradient update
                     if (
                         self._run_val_every_n_steps is not None
@@ -800,9 +815,9 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     break
 
             self.epochs_run += 1
-            self.save_checkpoint(epoch=curr_epoch)
 
         self._profiler.stop()
+        self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
     def _loss_step(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
         # Shape [b, s], needed for the loss not the model

--- a/recipes/qat_lora_finetune_distributed.py
+++ b/recipes/qat_lora_finetune_distributed.py
@@ -184,6 +184,8 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
         self._log_peak_memory_stats = cfg.get("log_peak_memory_stats", False)
         self._logger = utils.get_logger(cfg.log_level)
 
+        self.save_every_n_steps = cfg.get("save_every_n_steps")
+
         if (
             self._log_peak_memory_stats
             and self._device.type not in VALID_BACKENDS_FOR_MEMORY_STATS
@@ -381,6 +383,12 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
         ):
             self._steps_per_epoch = self.max_steps_per_epoch
         self.global_step = self.epochs_run * self._steps_per_epoch
+
+        if self.save_every_n_steps is None:
+            self.save_every_n_steps = self._steps_per_epoch
+            self.checkpoint_dir_prefix = "epoch"
+        else:
+            self.checkpoint_dir_prefix = "step"
 
         # Learning rate scheduler can only be set up after number of steps
         # has been computed
@@ -668,6 +676,7 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
     def save_checkpoint(
         self,
         epoch: int,
+        full_tensors: bool,
     ) -> None:
         self._checkpoint_client.save_checkpoint(
             model=self._model,
@@ -682,6 +691,7 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
             epoch=epoch,
             adapter_config=self._adapter_config.copy(),
             adapter_only=self._save_adapter_weights_only,
+            full_tensors=full_tensors
         )
 
     def train(self) -> None:
@@ -833,8 +843,11 @@ class QATLoRAFinetuneRecipeDistributed(FTRecipeInterface):
                     # will include multiple forward / backward passes if gradient accumulation > 1
                     self._profiler.step()
 
+                    if self.global_step % self.save_every_n_steps == 0:
+                        self.save_checkpoint(epoch=curr_epoch, full_tensors=False)
+
             self.epochs_run += 1
-            self.save_checkpoint(epoch=curr_epoch)
+        self.save_checkpoint(epoch=curr_epoch, full_tensors=True)
 
         self._profiler.stop()
 

--- a/tests/recipes/test_full_dpo_distributed.py
+++ b/tests/recipes/test_full_dpo_distributed.py
@@ -211,7 +211,7 @@ class TestFullDPODistributedRecipe:
             metric_logger.filename={resumed_log_file} \
             enable_async_checkpointing=True \
         """.split()
-        cmd_2 = cmd_2 + self._get_test_config_overrides(epochs=1) + model_config
+        cmd_2 = cmd_2 + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd_2)
         runpy.run_path(TUNE_PATH, run_name="__main__")
 

--- a/tests/recipes/test_full_dpo_distributed.py
+++ b/tests/recipes/test_full_dpo_distributed.py
@@ -216,5 +216,5 @@ class TestFullDPODistributedRecipe:
 
         resumed_loss_values = get_loss_values_from_metric_logger(resumed_log_file)
         torch.testing.assert_close(
-            resumed_loss_values, self.expected_loss_values()[2:], rtol=1e-5, atol=1e-5
+            resumed_loss_values, self.expected_loss_values(), rtol=1e-5, atol=1e-5
         )

--- a/tests/recipes/test_full_finetune_distributed.py
+++ b/tests/recipes/test_full_finetune_distributed.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import runpy
 import shutil
 import sys
@@ -293,10 +294,6 @@ class TestFullFinetuneDistributedRecipe:
         # Resume training
         epoch_folder = get_largest_iter_folder(tmpdir)
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
-        suffix = ".safetensors" if ckpt_type == "hf" else ".bin"
-        model_ckpt_fname = (
-            SHARD_FNAME.format(cpt_idx="1".zfill(5), num_shards="1".zfill(5)) + suffix
-        )
 
         cmd_2 = f"""
         tune run --nnodes 1 --nproc_per_node 2 full_finetune_distributed \
@@ -304,9 +301,8 @@ class TestFullFinetuneDistributedRecipe:
             batch_size={micro_batch_size} \
             gradient_accumulation_steps={gradient_accumulation_steps} \
             output_dir={tmpdir} \
-            checkpointer._component_={ckpt_component} \
             checkpointer.checkpoint_dir='{tmpdir}/{epoch_folder_minus_one}' \
-            checkpointer.checkpoint_files=[{os.path.join(epoch_folder_minus_one, model_ckpt_fname)}]\
+            checkpointer.checkpoint_files=["model.safetensors"]\
             checkpointer.output_dir={tmpdir} \
             tokenizer.path='{tokenizer_path}' \
             tokenizer.prompt_template=null \

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -218,26 +218,11 @@ class TestFullFinetuneSingleDeviceRecipe:
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
         # 2. Find the checkpoint at the end of the first epoch
-        # step_folder = get_largest_iter_folder(tmpdir, pattern=r"^step_(\d+)")
-        # step_folder_at_epoch_boundary = f"step_{int(step_folder.split('_')[-1]) - 2}"
         suffix = ".safetensors"
         model_ckpt_fname = (
             "model" + suffix
         )
-        # assert step_folder is not None, "No step folder found"
         assert os.path.exists(os.path.join(tmpdir, prev_ckpt_dir, model_ckpt_fname)), "Checkpoint file does not exist"
-
-        def print_file_tree(start_path='.', indent=''):
-            for i, item in enumerate(sorted(os.listdir(start_path))):
-                path = os.path.join(start_path, item)
-                is_last = (i == len(os.listdir(start_path)) - 1)
-                pointer = '└── ' if is_last else '├── '
-                print(indent + pointer + item)
-                if os.path.isdir(path):
-                    extension = '    ' if is_last else '│   '
-                    print_file_tree(path, indent + extension)
-
-        print_file_tree(tmpdir)
 
         shutil.rmtree(tmpdir / final_ckpt_dir)
 

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -214,18 +214,10 @@ class TestFullFinetuneSingleDeviceRecipe:
 
         # 2. Find the checkpoint at the end of the first epoch
         suffix = ".safetensors"
-<<<<<<< HEAD
         model_ckpt_fname = (
             "model" + suffix
         )
         assert os.path.exists(os.path.join(tmpdir, prev_ckpt_dir, model_ckpt_fname)), "Checkpoint file does not exist"
-=======
-        model_ckpt_fname = "model" + suffix
-        assert step_folder is not None, "No step folder found"
-        assert os.path.exists(
-            os.path.join(tmpdir, step_folder_at_epoch_boundary, model_ckpt_fname)
-        ), "Checkpoint file does not exist"
->>>>>>> joecummings/impl-step-based-ckpt
 
         shutil.rmtree(tmpdir / final_ckpt_dir)
 

--- a/tests/recipes/test_full_finetune_single_device.py
+++ b/tests/recipes/test_full_finetune_single_device.py
@@ -212,18 +212,6 @@ class TestFullFinetuneSingleDeviceRecipe:
         with pytest.raises(SystemExit, match=""):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        def print_file_tree(start_path='.', indent=''):
-            for i, item in enumerate(sorted(os.listdir(start_path))):
-                path = os.path.join(start_path, item)
-                is_last = (i == len(os.listdir(start_path)) - 1)
-                pointer = '└── ' if is_last else '├── '
-                print(indent + pointer + item)
-                if os.path.isdir(path):
-                    extension = '    ' if is_last else '│   '
-                    print_file_tree(path, indent + extension)
-
-        print_file_tree(tmpdir)
-
         # 2. Find the checkpoint at the end of the first epoch
         suffix = ".safetensors"
         model_ckpt_fname = (
@@ -231,21 +219,7 @@ class TestFullFinetuneSingleDeviceRecipe:
         )
         assert os.path.exists(os.path.join(tmpdir, prev_ckpt_dir, model_ckpt_fname)), "Checkpoint file does not exist"
 
-        print(f'{final_ckpt_dir=}')
-
         shutil.rmtree(tmpdir / final_ckpt_dir)
-
-        def print_file_tree(start_path='.', indent=''):
-            for i, item in enumerate(sorted(os.listdir(start_path))):
-                path = os.path.join(start_path, item)
-                is_last = (i == len(os.listdir(start_path)) - 1)
-                pointer = '└── ' if is_last else '├── '
-                print(indent + pointer + item)
-                if os.path.isdir(path):
-                    extension = '    ' if is_last else '│   '
-                    print_file_tree(path, indent + extension)
-
-        print_file_tree(tmpdir)
 
         # 3. Resume training w/ the checkpoint from epoch boundary
         cmd_2 = f"""
@@ -270,24 +244,10 @@ class TestFullFinetuneSingleDeviceRecipe:
         with pytest.raises(SystemExit, match=""):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        def print_file_tree(start_path='.', indent=''):
-            for i, item in enumerate(sorted(os.listdir(start_path))):
-                path = os.path.join(start_path, item)
-                is_last = (i == len(os.listdir(start_path)) - 1)
-                pointer = '└── ' if is_last else '├── '
-                print(indent + pointer + item)
-                if os.path.isdir(path):
-                    extension = '    ' if is_last else '│   '
-                    print_file_tree(path, indent + extension)
-
-        print_file_tree(tmpdir)
-
         # 4. Make sure loss values match the expected values
         expected_loss_values = self._fetch_expected_loss_values(model_type)[2:]
         loss_values = get_loss_values_from_metric_logger(log_file)
 
-        print(f'{expected_loss_values=}')
-        print(f'{loss_values=}')
         torch.testing.assert_close(
             loss_values, expected_loss_values, rtol=1e-4, atol=1e-4
         )

--- a/tests/recipes/test_knowledge_distillation_distributed.py
+++ b/tests/recipes/test_knowledge_distillation_distributed.py
@@ -32,7 +32,6 @@ from torchtune import config
 from torchtune.training.checkpointing._utils import (
     ADAPTER_MODEL_FNAME,
     get_largest_iter_folder,
-    RECIPE_STATE_DIRNAME,
     safe_torch_load,
     SHARD_FNAME,
 )
@@ -171,7 +170,7 @@ class TestKDDistributedRecipe:
             checkpointer.checkpoint_dir={ckpt_dir} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
-            checkpointer.recipe_checkpoint={os.path.join(RECIPE_STATE_DIRNAME, "recipe_state.pt")}
+            checkpointer.recipe_checkpoint={os.path.join(epoch_folder_minus_one, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
             teacher_checkpointer._component_=torchtune.training.FullModelTorchTuneCheckpointer \
             teacher_checkpointer.checkpoint_dir='{ckpt_dir}' \

--- a/tests/recipes/test_knowledge_distillation_distributed.py
+++ b/tests/recipes/test_knowledge_distillation_distributed.py
@@ -145,6 +145,7 @@ class TestKDDistributedRecipe:
             teacher_checkpointer.checkpoint_dir='{ckpt_dir}' \
             teacher_checkpointer.checkpoint_files=[{ckpt_path}] \
             teacher_checkpointer.output_dir={tmpdir} \
+            metric_logger.filename={log_file} \
             tokenizer.path={tokenizer_path} \
             tokenizer.prompt_template=null \
         """.split()
@@ -159,6 +160,17 @@ class TestKDDistributedRecipe:
         )
         monkeypatch.setattr(sys, "argv", cmd_1)
         runpy.run_path(TUNE_PATH, run_name="__main__")
+
+        expected_loss_values = self._fetch_expected_loss_values("llama3")
+        # because there're 3 losses: loss, class_loss, and kd_loss
+        loss_values = get_loss_values_from_metric_logger(log_file)[::3]
+
+        torch.testing.assert_close(
+            loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
+        )
+
+        resumed_log_dir = (tmpdir / "resumed/").mkdir()
+        resumed_log_file = gen_log_file_name(resumed_log_dir)
 
         # Resume training
         epoch_folder = get_largest_iter_folder(tmpdir)
@@ -178,13 +190,13 @@ class TestKDDistributedRecipe:
             teacher_checkpointer.checkpoint_files=[{ckpt_path}] \
             teacher_checkpointer.output_dir={tmpdir} \
             resume_from_checkpoint=True \
-            metric_logger.filename={log_file} \
+            metric_logger.filename={resumed_log_file} \
             tokenizer.path={tokenizer_path} \
             tokenizer.prompt_template=null \
         """.split()
         cmd_2 = (
             cmd_2
-            + self._get_test_config_overrides(epochs=3)
+            + self._get_test_config_overrides()
             + model_config
             + teacher_config
         )
@@ -192,14 +204,12 @@ class TestKDDistributedRecipe:
         runpy.run_path(TUNE_PATH, run_name="__main__")
 
         # Second epoch only
-        expected_loss_values = self._fetch_expected_loss_values("llama3")[2:]
-        loss_values = get_loss_values_from_metric_logger(log_file)
-        # only take the first loss
-        num_losses = int(len(loss_values) / 4)  # 2 steps per epoch, 2 epochs
-        loss_values = loss_values[0::num_losses][:2]
+        expected_loss_values = self._fetch_expected_loss_values("llama3")
+        # because there're 3 losses: loss, class_loss, and kd_loss
+        loss_values = get_loss_values_from_metric_logger(resumed_log_file)[::3]
 
         torch.testing.assert_close(
-            loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
+            loss_values[:2], expected_loss_values[2:], rtol=1e-5, atol=1e-5
         )
 
     @pytest.mark.integration_test

--- a/tests/recipes/test_knowledge_distillation_distributed.py
+++ b/tests/recipes/test_knowledge_distillation_distributed.py
@@ -47,6 +47,7 @@ class TestKDDistributedRecipe:
             f"epochs={epochs}",
             "dtype=fp32",
             "max_steps_per_epoch=2",
+            "optimizer=torch.optim.AdamW",
             "optimizer.lr=2e-5",
             "log_every_n_steps=1",
             "gradient_accumulation_steps=1",

--- a/tests/recipes/test_knowledge_distillation_single_device.py
+++ b/tests/recipes/test_knowledge_distillation_single_device.py
@@ -194,18 +194,21 @@ class TestKDSingleDeviceRecipe:
         with pytest.raises(SystemExit, match=""):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        # Resume training
+        epoch_folder = get_largest_iter_folder(tmpdir)
+        epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
+
         shutil.rmtree(tmpdir / "epoch_1")
 
+        # Resume training
         cmd_2 = f"""
         tune run knowledge_distillation_single_device \
             --config qwen2/1.5_to_0.5B_KD_lora_single_device \
             output_dir={tmpdir} \
             checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
-            checkpointer.checkpoint_dir={ckpt_dir} \
+            checkpointer.checkpoint_dir={tmpdir}/epoch_0 \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
-            checkpointer.recipe_checkpoint='recipe_state.pt' \
+            checkpointer.recipe_checkpoint={os.path.join(epoch_folder_minus_one, "recipe_state.pt")}
             checkpointer.model_type=LLAMA3 \
             teacher_checkpointer._component_=torchtune.training.FullModelTorchTuneCheckpointer \
             teacher_checkpointer.checkpoint_dir='{ckpt_dir}' \

--- a/tests/recipes/test_knowledge_distillation_single_device.py
+++ b/tests/recipes/test_knowledge_distillation_single_device.py
@@ -226,7 +226,7 @@ class TestKDSingleDeviceRecipe:
         """.split()
         cmd_2 = (
             cmd_2
-            + self._get_test_config_overrides(epochs=3)
+            + self._get_test_config_overrides()
             + model_config
             + teacher_config
         )
@@ -235,14 +235,12 @@ class TestKDSingleDeviceRecipe:
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
         # Second epoch only
-        expected_loss_values = self._fetch_expected_loss_values("llama3")[2:]
-        loss_values = get_loss_values_from_metric_logger(log_file)
-        # only take the first loss
-        num_losses = int(len(loss_values) / 4)  # 2 steps per epoch, 2 epochs
-        loss_values = loss_values[0::num_losses][:2]
+        expected_loss_values = self._fetch_expected_loss_values("llama3")
+        # because there're 3 losses: loss, class_loss, and kd_loss
+        loss_values = get_loss_values_from_metric_logger(log_file)[::3]
 
         torch.testing.assert_close(
-            loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
+            loss_values[:2], expected_loss_values[2:], rtol=1e-5, atol=1e-5
         )
 
     @pytest.mark.integration_test

--- a/tests/recipes/test_knowledge_distillation_single_device.py
+++ b/tests/recipes/test_knowledge_distillation_single_device.py
@@ -48,6 +48,7 @@ class TestKDSingleDeviceRecipe:
             "seed=9",
             f"epochs={epochs}",
             "max_steps_per_epoch=2",
+            "optimizer=torch.optim.AdamW",
             "optimizer.lr=2e-5",
             "log_every_n_steps=1",
             "gradient_accumulation_steps=1",

--- a/tests/recipes/test_knowledge_distillation_single_device.py
+++ b/tests/recipes/test_knowledge_distillation_single_device.py
@@ -180,7 +180,6 @@ class TestKDSingleDeviceRecipe:
             tokenizer.prompt_template=null \
             ~tokenizer.merges_file \
             metric_logger._component_=torchtune.training.metric_logging.DiskLogger \
-            enable_async_checkpointing=True \
         """.split()
 
         model_config = MODEL_TEST_CONFIGS["llama3_lora"]
@@ -209,6 +208,7 @@ class TestKDSingleDeviceRecipe:
             checkpointer.checkpoint_dir={tmpdir}/epoch_0 \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.output_dir={tmpdir} \
+            checkpointer.adapter_checkpoint={os.path.join(epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
             checkpointer.recipe_checkpoint={os.path.join(epoch_folder_minus_one, "recipe_state.pt")}
             checkpointer.model_type=LLAMA3 \
             teacher_checkpointer._component_=torchtune.training.FullModelTorchTuneCheckpointer \

--- a/tests/recipes/test_lora_dpo_distributed.py
+++ b/tests/recipes/test_lora_dpo_distributed.py
@@ -136,7 +136,7 @@ class TestLoRADPODistributedRecipe:
         runpy.run_path(TUNE_PATH, run_name="__main__")
 
         # Second epoch only
-        resumed_loss_values = get_loss_values_from_metric_logger(resumed_log_file)
+        resumed_loss_values = get_loss_values_from_metric_logger(resumed_log_file)[-2:]
 
         torch.testing.assert_close(
             resumed_loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
@@ -207,7 +207,6 @@ class TestLoRADPODistributedRecipe:
             checkpointer.checkpoint_dir={ckpt_dir} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
-            checkpointer.recipe_checkpoint={os.path.join(tmpdir, RECIPE_STATE_DIRNAME, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
             checkpointer.model_type=LLAMA2 \
             resume_from_checkpoint=True \

--- a/tests/recipes/test_lora_dpo_distributed.py
+++ b/tests/recipes/test_lora_dpo_distributed.py
@@ -8,6 +8,7 @@ import os
 import runpy
 import sys
 from pathlib import Path
+import shutil
 
 import pytest
 import torch
@@ -194,6 +195,8 @@ class TestLoRADPODistributedRecipe:
         resumed_log_dir = (tmpdir / "resumed/").mkdir()
         resumed_log_file = gen_log_file_name(resumed_log_dir)
 
+        shutil.rmtree(tmpdir / 'epoch_1')
+
         # Resume training
         epoch_folder = get_largest_iter_folder(tmpdir)
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
@@ -225,7 +228,7 @@ class TestLoRADPODistributedRecipe:
         resumed_loss_values = get_loss_values_from_metric_logger(resumed_log_file)
 
         torch.testing.assert_close(
-            resumed_loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
+            resumed_loss_values[-2:], expected_loss_values, rtol=1e-5, atol=1e-5
         )
 
     @pytest.mark.integration_test

--- a/tests/recipes/test_lora_dpo_distributed.py
+++ b/tests/recipes/test_lora_dpo_distributed.py
@@ -119,10 +119,9 @@ class TestLoRADPODistributedRecipe:
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
             checkpointer=torchtune.training.FullModelHFCheckpointer \
-            checkpointer.checkpoint_dir={ckpt_dir} \
+            checkpointer.checkpoint_dir={os.path.join(tmpdir, epoch_folder_minus_one)} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
-            checkpointer.recipe_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
             checkpointer.model_type=LLAMA2 \
             resume_from_checkpoint=True \

--- a/tests/recipes/test_lora_dpo_single_device.py
+++ b/tests/recipes/test_lora_dpo_single_device.py
@@ -119,10 +119,9 @@ class TestLoRADPOSingleDeviceRecipe:
             model.lora_attn_modules=['q_proj','v_proj'] \
             model.apply_lora_to_mlp=False \
             checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
-            checkpointer.checkpoint_dir={ckpt_dir} \
+            checkpointer.checkpoint_dir={os.path.join(tmpdir, epoch_folder_minus_one)} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
-            checkpointer.recipe_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
             checkpointer.model_type=LLAMA3 \
             resume_from_checkpoint=True \

--- a/tests/recipes/test_lora_finetune_distributed.py
+++ b/tests/recipes/test_lora_finetune_distributed.py
@@ -211,7 +211,7 @@ class TestLoRAFinetuneDistributedRecipe:
 
         expected_loss_values = self._fetch_expected_loss_values(model_type)[2:]
 
-        loss_values = get_loss_values_from_metric_logger(log_file)
+        loss_values = get_loss_values_from_metric_logger(log_file)[2:]
         torch.testing.assert_close(
             loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
         )
@@ -310,7 +310,7 @@ class TestLoRAFinetuneDistributedRecipe:
         monkeypatch.setattr(sys, "argv", cmd_2)
         runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        expected_loss_values = self._fetch_expected_loss_values(model_type)[2:]
+        expected_loss_values = self._fetch_expected_loss_values(model_type)
 
         loss_values = get_loss_values_from_metric_logger(log_file)
         torch.testing.assert_close(

--- a/tests/recipes/test_lora_finetune_single_device.py
+++ b/tests/recipes/test_lora_finetune_single_device.py
@@ -265,14 +265,14 @@ class TestLoRAFinetuneSingleDeviceRecipe:
             enable_activation_checkpointing=True \
             enable_activation_offloading=False \
         """.split()
-        cmd_2 = cmd_2 + self._get_test_config_overrides(epochs=3) + model_config
+        cmd_2 = cmd_2 + self._get_test_config_overrides() + model_config
         monkeypatch.setattr(sys, "argv", cmd_2)
         with pytest.raises(SystemExit, match=""):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
         # Second epoch only
-        expected_loss_values = self._fetch_expected_loss_values("llama3")[2:]
-        loss_values = get_loss_values_from_metric_logger(log_file)[:2]
+        expected_loss_values = self._fetch_expected_loss_values("llama3")
+        loss_values = get_loss_values_from_metric_logger(log_file)
 
         torch.testing.assert_close(
             loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
@@ -330,34 +330,8 @@ class TestLoRAFinetuneSingleDeviceRecipe:
         with pytest.raises(SystemExit, match=""):
             runpy.run_path(TUNE_PATH, run_name="__main__")
 
-        def print_file_tree(start_path='.', indent=''):
-            for i, item in enumerate(sorted(os.listdir(start_path))):
-                path = os.path.join(start_path, item)
-                is_last = (i == len(os.listdir(start_path)) - 1)
-                pointer = '└── ' if is_last else '├── '
-                print(indent + pointer + item)
-                if os.path.isdir(path):
-                    extension = '    ' if is_last else '│   '
-                    print_file_tree(path, indent + extension)
-
-        print_file_tree(tmpdir)
-        print("BREAK")
-
         # Resume training
         shutil.rmtree(tmpdir / "epoch_1")
-
-        def print_file_tree(start_path='.', indent=''):
-            for i, item in enumerate(sorted(os.listdir(start_path))):
-                path = os.path.join(start_path, item)
-                is_last = (i == len(os.listdir(start_path)) - 1)
-                pointer = '└── ' if is_last else '├── '
-                print(indent + pointer + item)
-                if os.path.isdir(path):
-                    extension = '    ' if is_last else '│   '
-                    print_file_tree(path, indent + extension)
-
-        print_file_tree(tmpdir)
-        print("BREAK")
 
         cmd_2 = f"""
         tune run lora_finetune_single_device \

--- a/tests/recipes/test_lora_finetune_single_device.py
+++ b/tests/recipes/test_lora_finetune_single_device.py
@@ -252,10 +252,10 @@ class TestLoRAFinetuneSingleDeviceRecipe:
             model.lora_attn_modules=['q_proj','v_proj','k_proj','output_proj'] \
             model.apply_lora_to_mlp=True \
             checkpointer=torchtune.training.FullModelTorchTuneCheckpointer \
-            checkpointer.checkpoint_dir={ckpt_dir} \
+            checkpointer.checkpoint_dir={os.path.join(tmpdir, epoch_folder_minus_one)} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
-            checkpointer.recipe_checkpoint={os.path.join(RECIPE_STATE_DIRNAME, "recipe_state.pt")}
+            checkpointer.recipe_checkpoint={os.path.join(tmpdir, epoch_folder_minus_one, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
             checkpointer.model_type=LLAMA3 \
             resume_from_checkpoint=True \

--- a/tests/recipes/test_ppo_full_finetune_single_device.py
+++ b/tests/recipes/test_ppo_full_finetune_single_device.py
@@ -28,7 +28,6 @@ from tests.test_utils import (
 
 from torchtune.training.checkpointing._utils import (
     get_largest_iter_folder,
-    RECIPE_STATE_DIRNAME,
     SHARD_FNAME,
 )
 
@@ -223,23 +222,20 @@ class TestPPOFullFinetuneSingleDeviceRecipe:
         epoch_folder = get_largest_iter_folder(value_tmpdir)
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
         policy_suffix = ".bin"
-        value_suffix = ".safetensors"
         policy_model_ckpt_fname = (
             SHARD_FNAME.format(cpt_idx="1".zfill(5), num_shards="1".zfill(5))
             + policy_suffix
         )
-        value_model_ckpt_fname = (
-            SHARD_FNAME.format(cpt_idx="1".zfill(5), num_shards="1".zfill(5))
-            + value_suffix
-        )
+        value_model_ckpt_fname = "model.safetensors"
+
         cmd_2 = f"""
         tune run ppo_full_finetune_single_device \
             --config mistral/7B_full_ppo_low_memory \
             output_dir={tmpdir} \
             checkpointer._component_=torchtune.training.FullModelTorchTuneCheckpointer \
-            checkpointer.checkpoint_dir='{ckpt_dir}' \
+            checkpointer.checkpoint_dir='{policy_tmpdir}/epoch_0' \
             checkpointer.checkpoint_files=[{os.path.join(epoch_folder_minus_one, policy_model_ckpt_fname)}]\
-            checkpointer.recipe_checkpoint={os.path.join(RECIPE_STATE_DIRNAME, "recipe_state.pt")}\
+            checkpointer.recipe_checkpoint={os.path.join(epoch_folder_minus_one, "recipe_state.pt")}\
             checkpointer.output_dir={policy_tmpdir} \
             checkpointer.model_type=LLAMA3 \
 
@@ -358,23 +354,20 @@ class TestPPOFullFinetuneSingleDeviceRecipe:
         epoch_folder = get_largest_iter_folder(value_tmpdir)
         epoch_folder_minus_one = f"epoch_{int(epoch_folder.split('_')[-1]) - 1}"
         policy_suffix = ".bin"
-        value_suffix = ".safetensors"
         policy_model_ckpt_fname = (
             SHARD_FNAME.format(cpt_idx="1".zfill(5), num_shards="1".zfill(5))
             + policy_suffix
         )
-        value_model_ckpt_fname = (
-            SHARD_FNAME.format(cpt_idx="1".zfill(5), num_shards="1".zfill(5))
-            + value_suffix
-        )
+        value_model_ckpt_fname = "model.safetensors"
+
         cmd_2 = f"""
         tune run ppo_full_finetune_single_device \
             --config mistral/7B_full_ppo_low_memory \
             output_dir={tmpdir} \
             checkpointer._component_=torchtune.training.FullModelTorchTuneCheckpointer \
-            checkpointer.checkpoint_dir='{ckpt_dir}' \
-            checkpointer.checkpoint_files=[{os.path.join(epoch_folder_minus_one, policy_model_ckpt_fname)}]\
-            checkpointer.recipe_checkpoint={os.path.join(RECIPE_STATE_DIRNAME, "recipe_state.pt")}\
+            checkpointer.checkpoint_dir='{policy_tmpdir}/epoch_0' \
+            checkpointer.checkpoint_files=[{os.path.join(epoch_folder_minus_one, policy_model_ckpt_fname)}] \
+            checkpointer.recipe_checkpoint={os.path.join(epoch_folder_minus_one, "recipe_state.pt")} \
             checkpointer.output_dir={policy_tmpdir} \
             checkpointer.model_type=LLAMA3 \
 

--- a/tests/recipes/test_qat_lora_finetune_distributed.py
+++ b/tests/recipes/test_qat_lora_finetune_distributed.py
@@ -189,7 +189,7 @@ class TestQATLoRAFinetuneDistributedRecipe:
             checkpointer.checkpoint_dir={ckpt_dir} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
-            checkpointer.recipe_checkpoint={os.path.join(RECIPE_STATE_DIRNAME, "recipe_state.pt")}
+            checkpointer.recipe_checkpoint={os.path.join(epoch_folder_minus_one, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
             checkpointer.model_type={model_type.upper()} \
             tokenizer.path='{tokenizer_path}' \
@@ -207,7 +207,7 @@ class TestQATLoRAFinetuneDistributedRecipe:
 
         expected_loss_values = self._fetch_expected_loss_values(model_type)[2:]
 
-        loss_values = get_loss_values_from_metric_logger(log_file)
+        loss_values = get_loss_values_from_metric_logger(log_file)[2:]
         torch.testing.assert_close(
             loss_values, expected_loss_values, rtol=1e-5, atol=1e-5
         )
@@ -290,7 +290,7 @@ class TestQATLoRAFinetuneDistributedRecipe:
             checkpointer.checkpoint_dir={ckpt_dir} \
             checkpointer.checkpoint_files=[{ckpt_path}]\
             checkpointer.adapter_checkpoint={os.path.join(epoch_folder_minus_one, f"{ADAPTER_MODEL_FNAME}.pt")}
-            checkpointer.recipe_checkpoint={os.path.join(RECIPE_STATE_DIRNAME, "recipe_state.pt")}
+            checkpointer.recipe_checkpoint={os.path.join(epoch_folder_minus_one, "recipe_state.pt")}
             checkpointer.output_dir={tmpdir} \
             checkpointer.model_type={model_type.upper()} \
             tokenizer.path='{tokenizer_path}' \

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -520,8 +520,7 @@ def gather_cpu_state_dict(
             param = param.to(param.dtype)
         if is_rank_zero:
             cpu_state_dict[param_name] = param.cpu()
-    _log.info(f"World: {torch.distributed.group.WORLD}")
-    _log.info(f'Rank {dist.get_rank()}: reached timeout barrier')
+            
     torch.distributed.barrier()
     if adapter_weights_only:
         cpu_state_dict = get_adapter_state_dict(cpu_state_dict, device=None)

--- a/torchtune/training/_distributed.py
+++ b/torchtune/training/_distributed.py
@@ -6,6 +6,7 @@
 
 
 import contextlib
+from datetime import timedelta
 import logging
 import os
 from copy import deepcopy
@@ -519,7 +520,9 @@ def gather_cpu_state_dict(
             param = param.to(param.dtype)
         if is_rank_zero:
             cpu_state_dict[param_name] = param.cpu()
-        torch.distributed.barrier()
+    _log.info(f"World: {torch.distributed.group.WORLD}")
+    _log.info(f'Rank {dist.get_rank()}: reached timeout barrier')
+    torch.distributed.barrier()
     if adapter_weights_only:
         cpu_state_dict = get_adapter_state_dict(cpu_state_dict, device=None)
     return cpu_state_dict

--- a/torchtune/training/checkpointing/_checkpoint_client.py
+++ b/torchtune/training/checkpointing/_checkpoint_client.py
@@ -226,7 +226,6 @@ class CheckpointClient:
             else:
                 save_path = save_path / f"epoch_{epoch}"
             save_path.mkdir(parents=True, exist_ok=True)
-            log.info(f"CHECKPOINT CLIENT Saving recipe_state.pt for full checkpoint at {save_path}")
             torch.save(
                 training_progress.state_dict(),
                 os.path.join(save_path, "recipe_state.pt"),
@@ -405,6 +404,7 @@ class CheckpointClient:
             intermediate_checkpoint = epoch + 1 < training_progress.total_epochs
 
         if not full_tensors and self._enable_async_checkpointing:
+            log.info('async checkpointing')
             self._save_checkpoint_async(
                 model,
                 optimizer,
@@ -417,6 +417,7 @@ class CheckpointClient:
             )
         elif full_tensors or not self._enable_async_checkpointing:
             # Only do sync checkpointing for full_tensors or when async is disabled
+            log.info('just sync checkpointing')
             self._save_checkpoint_sync(
                 model,
                 optimizer,

--- a/torchtune/training/checkpointing/_checkpoint_client.py
+++ b/torchtune/training/checkpointing/_checkpoint_client.py
@@ -273,16 +273,22 @@ class CheckpointClient:
         model_state_dict = {}
         optim_state_dict = {}
 
-        if is_distributed_checkpointer:
-            # For distributed checkpointers, use the model's state dict directly
-            model_state_dict = model.state_dict()
-        elif single_device:
-            # For single device, simply copy the model state to CPU
-            model_state_dict = {k: v.cpu() for k, v in model.state_dict().items()}
-        else:
-            # For non-distributed checkpointers in multi-device setups,
-            # consolidate the full model state dict on CPU for rank 0
-            # to prevent GPU memory from spiking during checkpoint save
+        if not is_distributed_checkpointer and not single_device:
+            # this logic is needed because staging an async checkpoint needs cpu
+            # which is also used here to save a sync checkpoint that causes issues when
+            # occurring concurrently. We should wait for async checkpoint to clear
+            # before saving a sync checkpoint that requires cpu gathering.
+            if self._get_dcp_checkpointer()._checkpoint_future is not None:
+                time_start_waiting = time.perf_counter()
+                self._get_dcp_checkpointer()._checkpoint_future.result()
+                if self._is_rank_zero:
+                    log.info(
+                        "Waiting for async checkpoint to finish, to save sync checkpoint ",
+                        f"took {time.perf_counter() - time_start_waiting:.2f} secs",
+                    )
+
+            # To prevent GPU memory from spiking during checkpoint save,
+            # we consolidate the full model and optim state dicts on CPU for rank 0
             model_state_dict = training.gather_cpu_state_dict(
                 model,
                 self._is_rank_zero,
@@ -293,6 +299,11 @@ class CheckpointClient:
                 log.info(
                     f"Getting full model state dict took {time.perf_counter() - cp_start:.2f} secs"
                 )
+
+        elif not is_distributed_checkpointer:
+            model_state_dict = {k: v.cpu() for k, v in model.state_dict().items()}
+        else:
+            model_state_dict = model.state_dict()
 
         if intermediate_checkpoint:
             if self._is_rank_zero:

--- a/torchtune/training/checkpointing/_checkpoint_client.py
+++ b/torchtune/training/checkpointing/_checkpoint_client.py
@@ -413,6 +413,7 @@ class CheckpointClient:
                 epoch,
                 adapter_config,
                 adapter_only,
+                single_device=single_device,
                 dir_prefix=dir_prefix,
             )
         else:

--- a/torchtune/training/checkpointing/_checkpoint_client.py
+++ b/torchtune/training/checkpointing/_checkpoint_client.py
@@ -142,7 +142,7 @@ class CheckpointClient:
     ) -> None:
         """
         Checkpoint the training state asynchronously as a distributed checkpoint. Saving
-        asnchronously unblocks the training sooner to continue for the next epoch.
+        asynchronously unblocks the training sooner to continue for the next epoch.
         The constructed checkpoint state dict contains the following information:
         - Model weights with key training.MODEL_KEY
         - Relevant recipe state, including optimizer, if training is not complete


### PR DESCRIPTION
Currently many tests for distributed checkpointing are passing but they are not correctly saving. The final directory is still using .distcp files instead of using .safetensors as aggregating the files in the final step is currently causing hangs.